### PR TITLE
Avoid floating point conversion on scalar case of adjust_volume

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,3 @@ criterion = "0.5"
 [[bench]]
 name = "simd_bench"
 harness = false
-
-
-# [profile.release]
-# debug=true

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,7 @@ fn main() {
     assert_eq!(gray_scalar, gray_simd, "std::simd result mismatch");
     assert_eq!(gray_scalar, gray_neon, "NEON result mismatch");
     println!("  ✓ Correctness verified\n");
+
     // ========================================================================
     // Scenario 2: Audio Processing - Volume Adjustment
     // ========================================================================


### PR DESCRIPTION
This changes the scalar case for the adjust volume to avoid converting the samples to float, and instead use the same approach of the neon case, ie: scaling the volume by 256 and then right shifting by 8