### PR TITLE
Improve portable_simd adjust_volume

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,7 @@ pub mod audio_processing {
     }
 
     pub mod portable_simd {
+        use std::simd::num::SimdInt;
         use std::simd::*;
         use std::simd::cmp::SimdOrd;
 
@@ -270,27 +271,22 @@ pub mod audio_processing {
             let len = samples.len();
             let simd_len = len - (len % 8);
 
-            for i in (0..simd_len).step_by(8) {
+            for chunk in samples[..simd_len].chunks_exact_mut(8) {
                 // i16 → i32 (avoid multiplication overflow)
-                let mut vals = [0i32; 8];
-                for j in 0..8 {
-                    vals[j] = samples[i + j] as i32;
-                }
-                let v = i32x8::from_array(vals);
+                let vals = i16x8::from_slice(chunk);
+                let v : i32x8= vals.cast();
 
                 // Multiply then shift right 8 bits (divide by 256)
                 let adjusted = (v * vol_vec) >> Simd::splat(8);
 
                 // Clamp to i16 range
-                let clamped = adjusted.simd_clamp(
+                let clamped: i16x8 = adjusted.simd_clamp(
                     i32x8::splat(-32768),
                     i32x8::splat(32767),
-                );
+                ).cast();
 
                 // Write back
-                for (j, &val) in clamped.to_array().iter().enumerate() {
-                    samples[i + j] = val as i16;
-                }
+                clamped.copy_to_slice(chunk);
             }
 
             // Handle remainder


### PR DESCRIPTION
Use from_slice / to_slice when copying into / out of simd. Use cast methods instead of doing it manually (which should use the appropiate simd instructions for it).

Performance is now equal to the NEON implementation. 

```
Benchmarking Audio Volume Adjustment/std::simd/10000000: Collecting 100 samples in Audio Volume Adjustment/std::simd/10000000
                        time:   [467.23 µs 468.11 µs 469.20 µs]
                        change: [-77.436% -77.281% -77.151%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  6 (6.00%) high severe
Benchmarking Audio Volume Adjustment/NEON/10000000: Collecting 100 samples in estimAudio Volume Adjustment/NEON/10000000
                        time:   [466.39 µs 467.37 µs 468.50 µs]
                        change: [+0.2272% +0.4994% +0.7917%] (p = 0.00 < 0.05)
                        Change within noise threshold.
 ```