### PR TITLE
Mix tracks: Use from_slide / copy_to_slice, use casting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,7 @@ pub mod audio_processing {
     }
 
     pub mod portable_simd {
+        use std::simd::num::SimdInt;
         use std::simd::*;
         use std::simd::cmp::SimdOrd;
 
@@ -307,23 +308,16 @@ pub mod audio_processing {
 
             for i in (0..simd_len).step_by(8) {
                 // Load and convert to i32
-                let mut a_vals = [0i32; 8];
-                let mut b_vals = [0i32; 8];
-                for j in 0..8 {
-                    a_vals[j] = track_a[i + j] as i32;
-                    b_vals[j] = track_b[i + j] as i32;
-                }
-
-                let a = i32x8::from_array(a_vals);
-                let b = i32x8::from_array(b_vals);
+                let a: i32x8 = i16x8::from_slice(&track_a[i..i+8]).cast();
+                let b: i32x8 = i16x8::from_slice(&track_b[i..i+8]).cast();
 
                 // Mix: (a + b) / 2
                 let mixed = (a + b) >> Simd::splat(1);
 
+                // Downcast:
+                let mixed_i16 : i16x8 = mixed.cast();
                 // Write back
-                for (j, &val) in mixed.to_array().iter().enumerate() {
-                    output[i + j] = val as i16;
-                }
+                mixed_i16.copy_to_slice(&mut output[i..i+8]);
             }
 
             // Handle remainder


### PR DESCRIPTION
Performance a lot closer to NEON:
```
Benchmarking Audio Mixing/std::simd/100000: Collecting 100 samples in estimated 5.0Audio Mixing/std::simd/100000
                        time:   [4.4383 µs 4.5160 µs 4.6092 µs]
                        change: [-89.209% -88.910% -88.567%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe
Benchmarking Audio Mixing/NEON/100000: Collecting 100 samples in estimated 5.0103 sAudio Mixing/NEON/100000
                        time:   [3.6388 µs 3.6740 µs 3.7212 µs]
                        change: [-3.4160% -0.7581% +1.8672%] (p = 0.58 > 0.05)
                        No change in performance detected.

```

Output ASM is not as clean as I'd love to see. There might be some extra tricks we can apply here. 
But I don't think we'll ever get it up to par with NEON, due to the lack of half add. 